### PR TITLE
Initial version of hwmonitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.idea/
+/build/
+/hwmonitor.iml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+all: compile run
+
+compile:
+	modulec -n no.ion.hwmonitor -v 0.1.0 -d build/classes -e no.ion.hwmonitor.Main -f build/ src -- --release 11
+
+run:
+	javahms --module-path build --module no.ion.hwmonitor
+
+re: clean all
+
+clean:
+	rm -rf build

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # hwmonitor
 Sensor monitoring on Ubuntu 20.04
+
+This project grew out from trying to observe the various temperatures, fan speed, and power
+of my machine as I was trying to tune the fan speed for optimal settings.  I have 3 sources
+of sensor data:
+
+ * `lm-sensors` gives the temperature of my Ryzen CPU,
+ * `liquidctl` gives the temperature of the liquid in my NZXT Kraken X62 AIO cooler,
+ * `nvidia-smi` gives GPU temperature, graphics card power draw, and fan speed
+   of my NVIDIA graphics card.  It is basically able to show any data in the
+    NVIDIA X Server Settings program.
+ 
+ This project just tries to gather information from these sources.
+ It uses Java Hybrid Modules System just for verification of that.

--- a/src/module-info.java
+++ b/src/module-info.java
@@ -1,0 +1,3 @@
+module no.ion.hwmonitor {
+    exports no.ion.hwmonitor;
+}

--- a/src/no/ion/hwmonitor/HardwareSensorLogger.java
+++ b/src/no/ion/hwmonitor/HardwareSensorLogger.java
@@ -1,0 +1,117 @@
+package no.ion.hwmonitor;
+
+import no.ion.hwmonitor.liquidctl.KrakenStats;
+import no.ion.hwmonitor.liquidctl.NzxtKraken;
+import no.ion.hwmonitor.lmsensors.LmSensors;
+import no.ion.hwmonitor.lmsensors.SensorStats;
+import no.ion.hwmonitor.nvidia.NvidiaSmi;
+import no.ion.hwmonitor.nvidia.NvidiaSmiStats;
+import no.ion.hwmonitor.process.ProcessExecutor;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.time.ZoneId;
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import static no.ion.hwmonitor.util.Exceptions.uncheck;
+import static no.ion.hwmonitor.util.Exceptions.uncheckIO;
+
+public class HardwareSensorLogger {
+    private static final String separator = " ";
+    private final Path logPath;
+    private final FileSystem fileSystem;
+    private final ProcessExecutor processExecutor;
+
+    private boolean hasNvidiaGraphicsCard = true;
+    private boolean hasNzxtKrakenXCooler = true;
+    private boolean hasLmSensors = true;
+
+    private final NvidiaSmi nvidiaSmi;
+    private final NzxtKraken nzxtKraken;
+    private final LmSensors lmSensors;
+
+    public HardwareSensorLogger(Path logPath) {
+        this.logPath = logPath;
+        fileSystem = logPath.getFileSystem();
+        processExecutor = new ProcessExecutor();
+        nvidiaSmi = new NvidiaSmi(fileSystem, processExecutor);
+        nzxtKraken = new NzxtKraken(fileSystem, processExecutor);
+        lmSensors = new LmSensors(fileSystem, processExecutor);
+    }
+
+    public static void main(String... args) {
+        if (args.length != 1 || args[0].equals("-h") || args[0].equals("--help") || args[0].equals("help")) {
+            usage(null);
+            return;
+        }
+
+        Path logPath = Paths.get(args[0]);
+        if (!Files.isDirectory(logPath.getParent())) {
+            usage("Parent directory of " + args[0] + " does not exist");
+            return;
+        }
+
+        HardwareSensorLogger logger = new HardwareSensorLogger(logPath);
+        logger.blockingStart();
+    }
+
+    private static void usage(String messageOrNull) {
+        if (messageOrNull != null) {
+            System.out.println(messageOrNull + "\n");
+        }
+
+        System.out.println("Takes one argument: the path to the hardware log file to append to");
+    }
+
+    public void blockingStart() {
+        boolean dummy = false;
+
+        for (logNow(); dummy; logNow()) {
+            sleepFor(Duration.ofSeconds(1));
+        }
+    }
+
+    private void sleepFor(Duration duration) {
+        uncheck(() -> Thread.sleep(duration.toMillis()), RuntimeException::new);
+    }
+
+    private void logNow() {
+        var string = new StringBuilder();
+
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone(ZoneId.systemDefault()));
+        string.append(String.format("%1$tF %1$tT%1$tz", calendar));
+
+        if (hasLmSensors) {
+            SensorStats stats = lmSensors.probe();
+            string.append(separator).append("cpu-temp=").append(stats.temperatureInput()).append('C');
+            string.append(separator).append("cpu-temp2=").append(stats.temperature2Input()).append('C');
+            string.append(separator).append("wifi-temp=").append(stats.temperatureWifi()).append('C');
+        }
+
+        if (hasNvidiaGraphicsCard) {
+            NvidiaSmiStats stats = nvidiaSmi.probeNvidiaDevice();
+            string.append(separator).append("gpu-temp=").append(stats.temperatureGpu()).append('C');
+            string.append(separator).append("gfx-power=").append(stats.powerDraw()).append('W');
+            string.append(separator).append("gpu-util=").append(stats.utilizationGpuInPercent()).append('%');
+            string.append(separator).append("gfx-fan=").append(stats.fanSpeedInPercent()).append('%');
+        }
+
+        if (hasNzxtKrakenXCooler) {
+            KrakenStats stats = nzxtKraken.probe();
+            string.append(separator).append("kraken-temp=").append(stats.temperature()).append('C');
+            string.append(separator).append("kraken-fan=").append(stats.fanSpeedRpm()).append("rpm");
+            string.append(separator).append("kraken-pump=").append(stats.pumpSpeedRpm()).append("rpm");
+        }
+
+        string.append('\n');
+
+        uncheckIO(() -> Files.write(logPath, string.toString().getBytes(StandardCharsets.UTF_8),
+                StandardOpenOption.CREATE, StandardOpenOption.APPEND));
+    }
+}

--- a/src/no/ion/hwmonitor/Main.java
+++ b/src/no/ion/hwmonitor/Main.java
@@ -1,0 +1,30 @@
+package no.ion.hwmonitor;
+
+import no.ion.hwmonitor.liquidctl.KrakenStats;
+import no.ion.hwmonitor.liquidctl.NzxtKraken;
+import no.ion.hwmonitor.lmsensors.LmSensors;
+import no.ion.hwmonitor.lmsensors.SensorStats;
+import no.ion.hwmonitor.nvidia.NvidiaSmi;
+import no.ion.hwmonitor.nvidia.NvidiaSmiStats;
+import no.ion.hwmonitor.process.ProcessExecutor;
+
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+
+public class Main {
+    public static void main(String... args) {
+        FileSystem fileSystem = FileSystems.getDefault();
+        ProcessExecutor executor = new ProcessExecutor();
+        NvidiaSmi nvidiaSmi = new NvidiaSmi(fileSystem, executor);
+        NvidiaSmiStats nvidiaSmiStats = nvidiaSmi.probeNvidiaDevice();
+        System.out.println(nvidiaSmiStats);
+
+        NzxtKraken nzxtKraken = new NzxtKraken(fileSystem, executor);
+        KrakenStats krakenStats = nzxtKraken.probe();
+        System.out.println(krakenStats);
+
+        LmSensors sensors = new LmSensors(fileSystem, executor);
+        SensorStats sensorStats = sensors.probe();
+        System.out.println(sensorStats);
+    }
+}

--- a/src/no/ion/hwmonitor/liquidctl/KrakenStats.java
+++ b/src/no/ion/hwmonitor/liquidctl/KrakenStats.java
@@ -1,0 +1,26 @@
+package no.ion.hwmonitor.liquidctl;
+
+public class KrakenStats {
+    private final float temperature;
+    private final int fanSpeedRpm;
+    private final int pumpSpeedRpm;
+
+    public KrakenStats(float temperature, int fanSpeedRpm, int pumpSpeedRpm) {
+        this.temperature = temperature;
+        this.fanSpeedRpm = fanSpeedRpm;
+        this.pumpSpeedRpm = pumpSpeedRpm;
+    }
+
+    public float temperature() { return temperature; }
+    public int fanSpeedRpm() { return fanSpeedRpm; }
+    public int pumpSpeedRpm() { return pumpSpeedRpm; }
+
+    @Override
+    public String toString() {
+        return "NzxtKrakenX{" +
+                "temperature=" + temperature +
+                ", fanSpeedRpm=" + fanSpeedRpm +
+                ", pumpSpeedRpm=" + pumpSpeedRpm +
+                '}';
+    }
+}

--- a/src/no/ion/hwmonitor/liquidctl/NzxtKraken.java
+++ b/src/no/ion/hwmonitor/liquidctl/NzxtKraken.java
@@ -1,0 +1,69 @@
+package no.ion.hwmonitor.liquidctl;
+
+import no.ion.hwmonitor.process.ProcessExecutor;
+import no.ion.hwmonitor.process.ProcessResult;
+
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class NzxtKraken {
+    private static final String LIQUIDCTL_PATH = "/usr/local/bin/liquidctl";
+
+    private static final Pattern LIQUID_TEMPERATURE_PATTERN = Pattern.compile("Liquid temperature[ \\t]*([0-9.]+)[ \\t]");
+    private static final Pattern FAN_SPEED_PATTERN = Pattern.compile("Fan speed[ \\t]*([0-9]+)[ \\t]+rpm");
+    private static final Pattern PUMP_SPEED_PATTERN = Pattern.compile("Pump speed[ \\t]*([0-9]+)[ \\t]+rpm");
+
+    private final FileSystem fileSystem;
+    private final ProcessExecutor executor;
+
+    public NzxtKraken(FileSystem fileSystem, ProcessExecutor executor) {
+        this.fileSystem = fileSystem;
+        this.executor = executor;
+    }
+
+    public boolean liquidctlIsInstalled() {
+        return Files.isExecutable(fileSystem.getPath(LIQUIDCTL_PATH));
+    }
+
+    public KrakenStats probe() {
+        if (!liquidctlIsInstalled()) {
+            throw new IllegalStateException(LIQUIDCTL_PATH + " is not installed");
+        }
+
+        ProcessResult result = executor.exec(LIQUIDCTL_PATH, "status");
+        if (result.exitCode() != 0) {
+            throw new RuntimeException("liquidctl failed with exit code " + result.exitCode() + ": " + result.outputAsUtf8());
+        }
+
+        // output of the format:
+        //   NZXT Kraken X (X42, X52, X62 or X72)
+        //   ├── Liquid temperature     30.2  °C
+        //   ├── Fan speed               460  rpm
+        //   ├── Pump speed             1959  rpm
+        //   └── Firmware version      4.0.2
+
+        String output = result.outputAsUtf8();
+
+        Matcher liquidMatcher = LIQUID_TEMPERATURE_PATTERN.matcher(output);
+        if (!liquidMatcher.find()) {
+            throw new IllegalArgumentException("Failed to find liquid temperature in output from " + LIQUIDCTL_PATH + ": " + output);
+        }
+
+        Matcher fanSpeedMatcher = FAN_SPEED_PATTERN.matcher(output);
+        if (!fanSpeedMatcher.find()) {
+            throw new IllegalArgumentException("Failed to find fan speed in output from " + LIQUIDCTL_PATH + ": " + output);
+        }
+
+        Matcher pumpSpeedMatcher = PUMP_SPEED_PATTERN.matcher(output);
+        if (!pumpSpeedMatcher.find()) {
+            throw new IllegalArgumentException("Failed to find pump speed in output from " + LIQUIDCTL_PATH + ": " + output);
+        }
+
+        return new KrakenStats(
+                Float.parseFloat(liquidMatcher.group(1)),
+                Integer.parseInt(fanSpeedMatcher.group(1)),
+                Integer.parseInt(pumpSpeedMatcher.group(1)));
+    }
+}

--- a/src/no/ion/hwmonitor/lmsensors/LmSensors.java
+++ b/src/no/ion/hwmonitor/lmsensors/LmSensors.java
@@ -1,0 +1,84 @@
+package no.ion.hwmonitor.lmsensors;
+
+import no.ion.hwmonitor.process.ProcessExecutor;
+
+import java.nio.file.FileSystem;
+
+public class LmSensors {
+    private final FileSystem fileSystem;
+    private final ProcessExecutor executor;
+
+    public LmSensors(FileSystem fileSystem, ProcessExecutor executor) {
+        this.fileSystem = fileSystem;
+        this.executor = executor;
+    }
+
+    private enum State { INITIAL, TDIE_FOUND }
+
+    public SensorStats probe() {
+        String output = executor.invoke(fileSystem.getPath("/usr/bin/sensors"), "-u");
+        String[] lines = output.split("\n");
+
+        // Example output:
+        //   iwlwifi_1-virtual-0
+        //   Adapter: Virtual device
+        //   temp1:
+        //     temp1_input: 48.000
+        //
+        //   k10temp-pci-00c3
+        //   Adapter: PCI adapter
+        //   Tdie:
+        //     temp1_input: 46.875
+        //     temp1_max: 70.000
+        //   Tctl:
+        //     temp2_input: 46.875
+
+        int i = 0;
+        verifyLine("iwlwifi_1-virtual-0", lines, i++);
+        verifyLine("Adapter: Virtual device", lines, i++);
+        verifyLine("temp1:", lines, i++);
+        float temperatureWifi = getFloatSuffix("  temp1_input: ", lines, i++);
+        verifyLine("", lines, i++);
+        verifyLine("k10temp-pci-00c3", lines, i++);
+        verifyLine("Adapter: PCI adapter", lines, i++);
+        verifyLine("Tdie:", lines, i++);
+        float temperatureInput = getFloatSuffix("  temp1_input: ", lines, i++);
+        float temperatureMax = getFloatSuffix("  temp1_max: ", lines, i++);
+        verifyLine("Tctl:", lines, i++);
+        float temperature2Input = getFloatSuffix("  temp2_input: ", lines, i++);
+
+        // no more lines since above split() removes trailing empty elements.
+        if (i != lines.length) {
+            throw new IllegalArgumentException("Got more output from sensors than expected: " + output);
+        }
+
+        return new SensorStats(temperatureWifi, temperatureInput, temperatureMax, temperature2Input);
+    }
+
+    private void verifyLine(String line, String[] lines, int index) {
+        if (index >= lines.length) {
+            throw new IllegalArgumentException("End-of-file reached from sensors: Expected a line '" + line + "'");
+        }
+
+        if (!lines[index].equals(line)) {
+            throw new IllegalArgumentException("Expected line '" + line + "' but got: " + lines[index]);
+        }
+    }
+
+    private String getStringSuffix(String prefix, String[] lines, int index) {
+        if (index >= lines.length) {
+            throw new IllegalArgumentException("End-of-file reached from sensors: Expected a line " + prefix);
+        }
+
+        String line = lines[index];
+        if (!line.startsWith(prefix)) {
+            throw new IllegalArgumentException("Line does not start with the expected prefix '" + prefix + "': " + line);
+        }
+
+        return line.substring(prefix.length());
+    }
+
+    private float getFloatSuffix(String prefix, String[] lines, int index) {
+        return Float.parseFloat(getStringSuffix(prefix, lines, index));
+    }
+}

--- a/src/no/ion/hwmonitor/lmsensors/SensorStats.java
+++ b/src/no/ion/hwmonitor/lmsensors/SensorStats.java
@@ -1,0 +1,30 @@
+package no.ion.hwmonitor.lmsensors;
+
+public class SensorStats {
+    private final float temperatureWifi;
+    private final float temperatureInput;
+    private final float temperatureMax;
+    private final float temperature2Input;
+
+    public SensorStats(float temperatureWifi, float temperatureInput, float temperatureMax, float temperature2Input) {
+        this.temperatureWifi = temperatureWifi;
+        this.temperatureInput = temperatureInput;
+        this.temperatureMax = temperatureMax;
+        this.temperature2Input = temperature2Input;
+    }
+
+    public float temperatureWifi() { return temperatureWifi; }
+    public float temperatureInput() { return temperatureInput; }
+    public float temperatureMax() { return temperatureMax; }
+    public float temperature2Input() { return temperature2Input; }
+
+    @Override
+    public String toString() {
+        return "SensorStats{" +
+                "temperatureWifi=" + temperatureWifi +
+                ", temperatureInput=" + temperatureInput +
+                ", temperatureMax=" + temperatureMax +
+                ", temperature2Input=" + temperature2Input +
+                '}';
+    }
+}

--- a/src/no/ion/hwmonitor/nvidia/NvidiaSmi.java
+++ b/src/no/ion/hwmonitor/nvidia/NvidiaSmi.java
@@ -1,0 +1,70 @@
+package no.ion.hwmonitor.nvidia;
+
+import no.ion.hwmonitor.process.ProcessExecutor;
+import no.ion.hwmonitor.process.ProcessResult;
+
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+
+public class NvidiaSmi {
+    private static final String NVIDIA_SMI_PATH = "/usr/bin/nvidia-smi";
+
+    private FileSystem fileSystem;
+    private ProcessExecutor executor;
+
+    public NvidiaSmi(FileSystem fileSystem, ProcessExecutor executor) {
+        this.fileSystem = fileSystem;
+        this.executor = executor;
+    }
+
+    public boolean usrBinNvidiaSmiIsInstalled() {
+        return Files.isExecutable(fileSystem.getPath(NVIDIA_SMI_PATH));
+    }
+
+    public NvidiaSmiStats probeNvidiaDevice() {
+        if (!usrBinNvidiaSmiIsInstalled()) {
+            throw new IllegalStateException(NVIDIA_SMI_PATH + " is not installed");
+        }
+
+        ProcessResult result = executor.exec(
+                NVIDIA_SMI_PATH,
+                "--format=csv,noheader,nounits",
+                "--query-gpu=count,fan.speed,memory.used,utilization.gpu,encoder.stats.averageFps,temperature.gpu,power.draw,power.limit");
+
+        if (result.exitCode() != 0) {
+            throw new RuntimeException("nvidia-smi failed with exit code " + result.exitCode() + ": " + result.outputAsUtf8());
+        }
+
+        String[] tokens = result.outputAsUtf8().split(", ", -1);
+        // "1, 0, 1041, 20, 0, 46, 24.47, 190.00"
+        final int expectedArguments = 8;
+        if (tokens.length != expectedArguments) {
+            throw new IllegalStateException("Expected " + expectedArguments + " but got " + tokens.length +
+                    ": " + result.outputAsUtf8());
+        }
+
+        int deviceCount = parseInt(tokens[0]);
+        switch (deviceCount) {
+            case 0: throw new IllegalStateException("Failed to find any NVidia devices");
+            case 1: break;
+            default: throw new IllegalStateException("Found more than one NVidia device with nvidia-smi: not yet supported");
+        }
+
+        return new NvidiaSmiStats(
+                parseInt(tokens[1]),
+                parseInt(tokens[2]),
+                parseInt(tokens[3]),
+                parseInt(tokens[4]),
+                parseInt(tokens[5]),
+                parseFloat(tokens[6]),
+                parseFloat(tokens[7]));
+    }
+
+    private int parseInt(String token) {
+        return Integer.parseInt(token);
+    }
+
+    private float parseFloat(String token) {
+        return Float.parseFloat(token);
+    }
+}

--- a/src/no/ion/hwmonitor/nvidia/NvidiaSmiStats.java
+++ b/src/no/ion/hwmonitor/nvidia/NvidiaSmiStats.java
@@ -1,0 +1,49 @@
+package no.ion.hwmonitor.nvidia;
+
+public class NvidiaSmiStats {
+    private final int fanSpeedInPercent;
+    private final int memoryUsedInMb;
+    private final int utilizationGpuInPercent;
+    private final int averageFps;
+    private final int temperatureGpu;
+    private final float powerDraw;
+    private final float powerLimit;
+
+    public NvidiaSmiStats(int fanSpeedInPercent,
+                          int memoryUsedInMb,
+                          int utilizationGpuInPercent,
+                          int averageFps,
+                          int temperatureGpu,
+                          float powerDraw,
+                          float powerLimit) {
+
+        this.fanSpeedInPercent = fanSpeedInPercent;
+        this.memoryUsedInMb = memoryUsedInMb;
+        this.utilizationGpuInPercent = utilizationGpuInPercent;
+        this.averageFps = averageFps;
+        this.temperatureGpu = temperatureGpu;
+        this.powerDraw = powerDraw;
+        this.powerLimit = powerLimit;
+    }
+
+    public int fanSpeedInPercent() { return fanSpeedInPercent; }
+    public int memoryUsedInMb() { return memoryUsedInMb; }
+    public int utilizationGpuInPercent() { return utilizationGpuInPercent; }
+    public int averageFps() { return averageFps; }
+    public int temperatureGpu() { return temperatureGpu; }
+    public float powerDraw() { return powerDraw; }
+    public float powerLimit() { return powerLimit; }
+
+    @Override
+    public String toString() {
+        return "NvidiaSmiResult{" +
+                "fanSpeedInPercent=" + fanSpeedInPercent +
+                ", memoryUsedInMb=" + memoryUsedInMb +
+                ", utilizationGpuInPercent=" + utilizationGpuInPercent +
+                ", averageFps=" + averageFps +
+                ", temperatureGpu=" + temperatureGpu +
+                ", powerDraw=" + powerDraw +
+                ", powerLimit=" + powerLimit +
+                '}';
+    }
+}

--- a/src/no/ion/hwmonitor/process/ProcessExecutor.java
+++ b/src/no/ion/hwmonitor/process/ProcessExecutor.java
@@ -1,0 +1,41 @@
+package no.ion.hwmonitor.process;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static no.ion.hwmonitor.util.Exceptions.uncheck;
+import static no.ion.hwmonitor.util.Exceptions.uncheckIO;
+
+public class ProcessExecutor {
+    public ProcessResult exec(String program, String... arguments) {
+        List<String> argumentVector = new ArrayList<>(1 + arguments.length);
+        argumentVector.add(program);
+        argumentVector.addAll(Arrays.asList(arguments));
+        ProcessBuilder builder = new ProcessBuilder(argumentVector)
+                .redirectErrorStream(true);
+        Process process = uncheckIO(builder::start);
+        InputStream inputStream = process.getInputStream();
+        byte[] outputBytes = uncheckIO(inputStream::readAllBytes);
+        int exitCode = uncheck(() -> process.waitFor());
+
+        return new ProcessResult(exitCode, outputBytes);
+    }
+
+    /** Same as {@link #exec}, but demands exit code 0 and returns output. */
+    public String invoke(Path program, String... arguments) {
+        if (!Files.isExecutable(program)) {
+            throw new IllegalStateException(program + " is not installed");
+        }
+
+        ProcessResult result = exec(program.toString(), arguments);
+        if (result.exitCode() != 0) {
+            throw new RuntimeException(program + " failed with exit code " + result.exitCode() + ": " + result.outputAsUtf8());
+        }
+
+        return result.outputAsUtf8();
+    }
+}

--- a/src/no/ion/hwmonitor/process/ProcessResult.java
+++ b/src/no/ion/hwmonitor/process/ProcessResult.java
@@ -1,0 +1,19 @@
+package no.ion.hwmonitor.process;
+
+import java.nio.charset.StandardCharsets;
+
+public class ProcessResult {
+    private final int exitCode;
+    private final byte[] outputBytes;
+
+    public ProcessResult(int exitCode, byte[] outputBytes) {
+        this.exitCode = exitCode;
+        this.outputBytes = outputBytes;
+    }
+
+    public int exitCode() { return exitCode; }
+
+    public String outputAsUtf8() {
+        return new String(outputBytes, StandardCharsets.UTF_8);
+    }
+}

--- a/src/no/ion/hwmonitor/util/Exceptions.java
+++ b/src/no/ion/hwmonitor/util/Exceptions.java
@@ -1,0 +1,55 @@
+package no.ion.hwmonitor.util;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.function.Function;
+
+public class Exceptions {
+    public interface SupplierThrowingException<T, E extends Exception> {
+        T get() throws E;
+    }
+
+    public static <T, E extends Exception> T uncheck(SupplierThrowingException<T, E> supplier) {
+        return uncheck(supplier, RuntimeException::new);
+    }
+
+    public static <T, E extends IOException> T uncheckIO(SupplierThrowingException<T, E> supplier) {
+        return uncheck(supplier, UncheckedIOException::new);
+    }
+
+    public static <T, E extends Exception> T uncheck(SupplierThrowingException<T, E> supplier,
+                                                     Function<E, RuntimeException> ExceptionToRuntimeExceptionMapper) {
+        try {
+            return supplier.get();
+        } catch (Exception e) {
+            // This cast is known to succeed
+            @SuppressWarnings("unchecked")
+            E a = (E) e;
+            throw ExceptionToRuntimeExceptionMapper.apply(a);
+        }
+    }
+
+    public interface RunnableThrowingException<E extends Exception> {
+        void get() throws E;
+    }
+
+    public static <E extends Exception> void uncheck(RunnableThrowingException<E> runnable) {
+        uncheck(runnable, RuntimeException::new);
+    }
+
+    public static <E extends IOException> void uncheckIO(RunnableThrowingException<E> runnable) {
+        uncheck(runnable, UncheckedIOException::new);
+    }
+
+    public static <E extends Exception> void uncheck(RunnableThrowingException<E> runnable,
+                                                     Function<E, RuntimeException> ExceptionToRuntimeExceptionMapper) {
+        try {
+            runnable.get();
+        } catch (Exception e) {
+            // This cast is known to succeed
+            @SuppressWarnings("unchecked")
+            E a = (E) e;
+            throw ExceptionToRuntimeExceptionMapper.apply(a);
+        }
+    }
+}


### PR DESCRIPTION
The source is made with a custom build using 'make' and hybridmodules (see
sibling project).  Just 'make' will print info from the 3 sensor sources
(lm-sensors, liquidctl, and nvidia-smi).  Then executing the following

javahms -p build -m no.ion.hwmonitor/no.ion.hwmonitor.HardwareSensorLogger ~/var/log/hw-sensor.log

will output a single line of HW info on temperature and fans to the log file.